### PR TITLE
Use entity ID instead of table uri for Atlas part

### DIFF
--- a/metadata_service/api/column.py
+++ b/metadata_service/api/column.py
@@ -20,32 +20,32 @@ class ColumnDescriptionAPI(Resource):
         super(ColumnDescriptionAPI, self).__init__()
 
     def put(self,
-            column_guid: str,
+            column_id: str,
             description_val: str) -> Iterable[Union[dict, tuple, int, None]]:
         """
         Updates column description
         """
         try:
-            self.client.put_column_description(column_guid=column_guid,
+            self.client.put_column_description(column_id=column_id,
                                                description=description_val)
 
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'column {} does not exist'.format(column_guid)
+            msg = 'column {} does not exist'.format(column_id)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
-    def get(self, column_guid: str) -> Union[tuple, int, None]:
+    def get(self, column_id: str) -> Union[tuple, int, None]:
         """
         Gets column descriptions in Neo4j
         """
         try:
-            description = self.client.get_column_description(column_guid=column_guid)
+            description = self.client.get_column_description(column_id=column_id)
 
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'column {} does not exist'.format(column_guid)
+            msg = 'column {} does not exist'.format(column_id)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
         except Exception:

--- a/metadata_service/api/column.py
+++ b/metadata_service/api/column.py
@@ -20,35 +20,32 @@ class ColumnDescriptionAPI(Resource):
         super(ColumnDescriptionAPI, self).__init__()
 
     def put(self,
-            table_uri: str,
-            column_name: str,
+            column_guid: str,
             description_val: str) -> Iterable[Union[dict, tuple, int, None]]:
         """
         Updates column description
         """
         try:
-            self.client.put_column_description(table_uri=table_uri,
-                                               column_name=column_name,
+            self.client.put_column_description(column_guid=column_guid,
                                                description=description_val)
 
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'table_uri {} with column {} does not exist'.format(table_uri, column_name)
+            msg = 'column {} does not exist'.format(column_guid)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
-    def get(self, table_uri: str, column_name: str) -> Union[tuple, int, None]:
+    def get(self, column_guid: str) -> Union[tuple, int, None]:
         """
         Gets column descriptions in Neo4j
         """
         try:
-            description = self.client.get_column_description(table_uri=table_uri,
-                                                             column_name=column_name)
+            description = self.client.get_column_description(column_guid=column_guid)
 
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'table_uri {} with column {} does not exist'.format(table_uri, column_name)
+            msg = 'column {} does not exist'.format(column_guid)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
         except Exception:

--- a/metadata_service/api/table.py
+++ b/metadata_service/api/table.py
@@ -89,13 +89,13 @@ class TableDetailAPI(Resource):
     def __init__(self) -> None:
         self.client = get_proxy_client()
 
-    def get(self, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def get(self, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            table = self.client.get_table(table_uri=table_uri)
+            table = self.client.get_table(table_guid=table_guid)
             return marshal(table, table_detail_fields), HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_uri)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
 
 
 class TableOwnerAPI(Resource):
@@ -106,27 +106,27 @@ class TableOwnerAPI(Resource):
     def __init__(self) -> None:
         self.client = get_proxy_client()
 
-    def put(self, table_uri: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, table_guid: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.add_owner(table_uri=table_uri, owner=owner)
+            self.client.add_owner(table_guid=table_guid, owner=owner)
             return {'message': 'The owner {} for table_uri {} '
                                'is added successfully'.format(owner,
-                                                              table_uri)}, HTTPStatus.OK
+                                                              table_guid)}, HTTPStatus.OK
         except Exception as e:
             return {'message': 'The owner {} for table_uri {} '
                                'is not added successfully'.format(owner,
-                                                                  table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                  table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, table_uri: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, table_guid: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.delete_owner(table_uri=table_uri, owner=owner)
+            self.client.delete_owner(table_guid=table_guid, owner=owner)
             return {'message': 'The owner {} for table_uri {} '
                                'is deleted successfully'.format(owner,
-                                                                table_uri)}, HTTPStatus.OK
+                                                                table_guid)}, HTTPStatus.OK
         except Exception:
             return {'message': 'The owner {} for table_uri {} '
                                'is not deleted successfully'.format(owner,
-                                                                    table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                    table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class TableDescriptionAPI(Resource):
@@ -141,33 +141,33 @@ class TableDescriptionAPI(Resource):
 
         super(TableDescriptionAPI, self).__init__()
 
-    def get(self, table_uri: str) -> Iterable[Any]:
+    def get(self, table_guid: str) -> Iterable[Any]:
         """
         Returns description in Neo4j endpoint
         """
         try:
-            description = self.client.get_table_description(table_uri=table_uri)
+            description = self.client.get_table_description(table_guid=table_guid)
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_uri)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
 
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, table_uri: str, description_val: str) -> Iterable[Any]:
+    def put(self, table_guid: str, description_val: str) -> Iterable[Any]:
         """
         Updates table description
-        :param table_uri:
+        :param table_guid:
         :param description_val:
         :return:
         """
         try:
-            self.client.put_table_description(table_uri=table_uri, description=description_val)
+            self.client.put_table_description(table_guid=table_guid, description=description_val)
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_uri)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
 
 
 class TableTagAPI(Resource):
@@ -182,42 +182,42 @@ class TableTagAPI(Resource):
         self.parser.add_argument('tag', type=str, location='json')
         super(TableTagAPI, self).__init__()
 
-    def put(self, table_uri: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, table_guid: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
         """
         API to add a tag to existing table uri.
 
-        :param table_uri:
+        :param table_guid:
         :param tag:
         :return:
         """
         try:
-            self.client.add_tag(table_uri=table_uri, tag=tag)
+            self.client.add_tag(table_guid=table_guid, tag=tag)
             return {'message': 'The tag {} for table_uri {} '
                                'is added successfully'.format(tag,
-                                                              table_uri)}, HTTPStatus.OK
+                                                              table_guid)}, HTTPStatus.OK
         except NotFoundException:
             return \
                 {'message': 'The tag {} for table_uri {} '
                             'is not added successfully'.format(tag,
-                                                               table_uri)}, \
+                                                               table_guid)}, \
                 HTTPStatus.NOT_FOUND
 
-    def delete(self, table_uri: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, table_guid: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
         """
         API to remove a association between a given tag and a table.
 
-        :param table_uri:
+        :param table_guid:
         :param tag:
         :return:
         """
         try:
-            self.client.delete_tag(table_uri=table_uri, tag=tag)
+            self.client.delete_tag(table_guid=table_guid, tag=tag)
             return {'message': 'The tag {} for table_uri {} '
                                'is deleted successfully'.format(tag,
-                                                                table_uri)}, HTTPStatus.OK
+                                                                table_guid)}, HTTPStatus.OK
         except NotFoundException:
             return \
                 {'message': 'The tag {} for table_uri {} '
                             'is not deleted successfully'.format(tag,
-                                                                 table_uri)}, \
+                                                                 table_guid)}, \
                 HTTPStatus.NOT_FOUND

--- a/metadata_service/api/table.py
+++ b/metadata_service/api/table.py
@@ -89,13 +89,13 @@ class TableDetailAPI(Resource):
     def __init__(self) -> None:
         self.client = get_proxy_client()
 
-    def get(self, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
+    def get(self, table_id: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            table = self.client.get_table(table_guid=table_guid)
+            table = self.client.get_table(table_id=table_id)
             return marshal(table, table_detail_fields), HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_id {} does not exist'.format(table_id)}, HTTPStatus.NOT_FOUND
 
 
 class TableOwnerAPI(Resource):
@@ -106,27 +106,27 @@ class TableOwnerAPI(Resource):
     def __init__(self) -> None:
         self.client = get_proxy_client()
 
-    def put(self, table_guid: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, table_id: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.add_owner(table_guid=table_guid, owner=owner)
-            return {'message': 'The owner {} for table_uri {} '
+            self.client.add_owner(table_id=table_id, owner=owner)
+            return {'message': 'The owner {} for table_id {} '
                                'is added successfully'.format(owner,
-                                                              table_guid)}, HTTPStatus.OK
+                                                              table_id)}, HTTPStatus.OK
         except Exception as e:
-            return {'message': 'The owner {} for table_uri {} '
+            return {'message': 'The owner {} for table_id {} '
                                'is not added successfully'.format(owner,
-                                                                  table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                  table_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, table_guid: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, table_id: str, owner: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.delete_owner(table_guid=table_guid, owner=owner)
-            return {'message': 'The owner {} for table_uri {} '
+            self.client.delete_owner(table_id=table_id, owner=owner)
+            return {'message': 'The owner {} for table_id {} '
                                'is deleted successfully'.format(owner,
-                                                                table_guid)}, HTTPStatus.OK
+                                                                table_id)}, HTTPStatus.OK
         except Exception:
-            return {'message': 'The owner {} for table_uri {} '
+            return {'message': 'The owner {} for table_id {} '
                                'is not deleted successfully'.format(owner,
-                                                                    table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                    table_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class TableDescriptionAPI(Resource):
@@ -141,33 +141,33 @@ class TableDescriptionAPI(Resource):
 
         super(TableDescriptionAPI, self).__init__()
 
-    def get(self, table_guid: str) -> Iterable[Any]:
+    def get(self, table_id: str) -> Iterable[Any]:
         """
         Returns description in Neo4j endpoint
         """
         try:
-            description = self.client.get_table_description(table_guid=table_guid)
+            description = self.client.get_table_description(table_id=table_id)
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_id {} does not exist'.format(table_id)}, HTTPStatus.NOT_FOUND
 
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, table_guid: str, description_val: str) -> Iterable[Any]:
+    def put(self, table_id: str, description_val: str) -> Iterable[Any]:
         """
         Updates table description
-        :param table_guid:
+        :param table_id:
         :param description_val:
         :return:
         """
         try:
-            self.client.put_table_description(table_guid=table_guid, description=description_val)
+            self.client.put_table_description(table_id=table_id, description=description_val)
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'table_uri {} does not exist'.format(table_guid)}, HTTPStatus.NOT_FOUND
+            return {'message': 'table_id {} does not exist'.format(table_id)}, HTTPStatus.NOT_FOUND
 
 
 class TableTagAPI(Resource):
@@ -182,42 +182,42 @@ class TableTagAPI(Resource):
         self.parser.add_argument('tag', type=str, location='json')
         super(TableTagAPI, self).__init__()
 
-    def put(self, table_guid: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, table_id: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
         """
-        API to add a tag to existing table uri.
+        API to add a tag to existing table id.
 
-        :param table_guid:
+        :param table_id:
         :param tag:
         :return:
         """
         try:
-            self.client.add_tag(table_guid=table_guid, tag=tag)
-            return {'message': 'The tag {} for table_uri {} '
+            self.client.add_tag(table_id=table_id, tag=tag)
+            return {'message': 'The tag {} for table_id {} '
                                'is added successfully'.format(tag,
-                                                              table_guid)}, HTTPStatus.OK
+                                                              table_id)}, HTTPStatus.OK
         except NotFoundException:
             return \
-                {'message': 'The tag {} for table_uri {} '
+                {'message': 'The tag {} for table_id {} '
                             'is not added successfully'.format(tag,
-                                                               table_guid)}, \
+                                                               table_id)}, \
                 HTTPStatus.NOT_FOUND
 
-    def delete(self, table_guid: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, table_id: str, tag: str) -> Iterable[Union[Mapping, int, None]]:
         """
         API to remove a association between a given tag and a table.
 
-        :param table_guid:
+        :param table_id:
         :param tag:
         :return:
         """
         try:
-            self.client.delete_tag(table_guid=table_guid, tag=tag)
-            return {'message': 'The tag {} for table_uri {} '
+            self.client.delete_tag(table_id=table_id, tag=tag)
+            return {'message': 'The tag {} for table_id {} '
                                'is deleted successfully'.format(tag,
-                                                                table_guid)}, HTTPStatus.OK
+                                                                table_id)}, HTTPStatus.OK
         except NotFoundException:
             return \
-                {'message': 'The tag {} for table_uri {} '
+                {'message': 'The tag {} for table_id {} '
                             'is not deleted successfully'.format(tag,
-                                                                 table_guid)}, \
+                                                                 table_id)}, \
                 HTTPStatus.NOT_FOUND

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -71,48 +71,48 @@ class UserFollowAPI(Resource):
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, user_id: str, resource_type: str, table_id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
         :param user_id:
-        :param table_guid:
+        :param table_id:
         :return:
         """
         try:
-            self.client.add_table_relation_by_user(table_guid=table_guid,
+            self.client.add_table_relation_by_user(table_id=table_id,
                                                    user_email=user_id,
                                                    relation_type=UserResourceRel.follow)
-            return {'message': 'The user {} for table_uri {} '
+            return {'message': 'The user {} for table_id {} '
                                'is added successfully'.format(user_id,
-                                                              table_guid)}, HTTPStatus.OK
+                                                              table_id)}, HTTPStatus.OK
         except Exception as e:
-            return {'message': 'The user {} for table_uri {} '
+            return {'message': 'The user {} for table_id {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_guid)}, \
+                                                                  table_id)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, user_id: str, resource_type: str, table_id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Delete the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
         :param user_id:
-        :param table_guid:
+        :param table_id:
         :return:
         """
         try:
-            self.client.delete_table_relation_by_user(table_guid=table_guid,
+            self.client.delete_table_relation_by_user(table_id=table_id,
                                                       user_email=user_id,
                                                       relation_type=UserResourceRel.follow)
-            return {'message': 'The user {} for table_uri {} '
+            return {'message': 'The user {} for table_id {} '
                                'is added successfully'.format(user_id,
-                                                              table_guid)}, HTTPStatus.OK
+                                                              table_id)}, HTTPStatus.OK
         except Exception as e:
-            return {'message': 'The user {} for table_uri {} '
+            return {'message': 'The user {} for table_id {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_guid)}, \
+                                                                  table_id)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -144,35 +144,35 @@ class UserOwnAPI(Resource):
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, user_id: str, resource_type: str, table_id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
 
         :param user_id:
         :param resource_type:
-        :param table_guid:
+        :param table_id:
         :return:
         """
         try:
-            self.client.add_owner(table_guid=table_guid, owner=user_id)
-            return {'message': 'The owner {} for table_uri {} '
+            self.client.add_owner(table_id=table_id, owner=user_id)
+            return {'message': 'The owner {} for table_id {} '
                                'is added successfully'.format(user_id,
-                                                              table_guid)}, HTTPStatus.OK
+                                                              table_id)}, HTTPStatus.OK
         except Exception as e:
-            return {'message': 'The owner {} for table_uri {} '
+            return {'message': 'The owner {} for table_id {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                  table_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, user_id: str, resource_type: str, table_id: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.delete_owner(table_guid=table_guid, owner=user_id)
-            return {'message': 'The owner {} for table_uri {} '
+            self.client.delete_owner(table_id=table_id, owner=user_id)
+            return {'message': 'The owner {} for table_id {} '
                                'is deleted successfully'.format(user_id,
-                                                                table_guid)}, HTTPStatus.OK
+                                                                table_id)}, HTTPStatus.OK
         except Exception:
-            return {'message': 'The owner {} for table_uri {} '
+            return {'message': 'The owner {} for table_id {} '
                                'is not deleted successfully'.format(user_id,
-                                                                    table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                    table_id)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class UserReadAPI(Resource):

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -71,48 +71,48 @@ class UserFollowAPI(Resource):
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
         :param user_id:
-        :param table_uri:
+        :param table_guid:
         :return:
         """
         try:
-            self.client.add_table_relation_by_user(table_uri=table_uri,
+            self.client.add_table_relation_by_user(table_guid=table_guid,
                                                    user_email=user_id,
                                                    relation_type=UserResourceRel.follow)
             return {'message': 'The user {} for table_uri {} '
                                'is added successfully'.format(user_id,
-                                                              table_uri)}, HTTPStatus.OK
+                                                              table_guid)}, HTTPStatus.OK
         except Exception as e:
             return {'message': 'The user {} for table_uri {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_uri)}, \
+                                                                  table_guid)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Delete the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
         :param user_id:
-        :param table_uri:
+        :param table_guid:
         :return:
         """
         try:
-            self.client.delete_table_relation_by_user(table_uri=table_uri,
+            self.client.delete_table_relation_by_user(table_guid=table_guid,
                                                       user_email=user_id,
                                                       relation_type=UserResourceRel.follow)
             return {'message': 'The user {} for table_uri {} '
                                'is added successfully'.format(user_id,
-                                                              table_uri)}, HTTPStatus.OK
+                                                              table_guid)}, HTTPStatus.OK
         except Exception as e:
             return {'message': 'The user {} for table_uri {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_uri)}, \
+                                                                  table_guid)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -144,35 +144,35 @@ class UserOwnAPI(Resource):
         except Exception:
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
 
         :param user_id:
         :param resource_type:
-        :param table_uri:
+        :param table_guid:
         :return:
         """
         try:
-            self.client.add_owner(table_uri=table_uri, owner=user_id)
+            self.client.add_owner(table_guid=table_guid, owner=user_id)
             return {'message': 'The owner {} for table_uri {} '
                                'is added successfully'.format(user_id,
-                                                              table_uri)}, HTTPStatus.OK
+                                                              table_guid)}, HTTPStatus.OK
         except Exception as e:
             return {'message': 'The owner {} for table_uri {} '
                                'is not added successfully'.format(user_id,
-                                                                  table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                  table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    def delete(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, user_id: str, resource_type: str, table_guid: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.delete_owner(table_uri=table_uri, owner=user_id)
+            self.client.delete_owner(table_guid=table_guid, owner=user_id)
             return {'message': 'The owner {} for table_uri {} '
                                'is deleted successfully'.format(user_id,
-                                                                table_uri)}, HTTPStatus.OK
+                                                                table_guid)}, HTTPStatus.OK
         except Exception:
             return {'message': 'The owner {} for table_uri {} '
                                'is not deleted successfully'.format(user_id,
-                                                                    table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+                                                                    table_guid)}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class UserReadAPI(Resource):

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -1,11 +1,13 @@
 import os
 
 # PROXY configuration keys
-PROXY_HOST = 'PROXY_HOST'
-PROXY_PORT = 'PROXY_PORT'
+PROXY_HOST = 'localhost'
+PROXY_PORT = '21000'
 PROXY_USER = 'PROXY_USER'
 PROXY_PASSWORD = 'PROXY_PASSWORD'
-PROXY_CLIENT = 'PROXY_CLIENT'
+PROXY_CLIENT = 'ATLAS'
+CREDENTIALS_PROXY_USER = 'admin'
+CREDENTIALS_PROXY_PASSWORD = 'admin'
 
 
 PROXY_CLIENTS = {
@@ -48,3 +50,5 @@ class LocalConfig(Config):
     PROXY_HOST = os.environ.get('PROXY_HOST', f'bolt://{LOCAL_HOST}')
     PROXY_PORT = os.environ.get('PROXY_PORT', 7687)
     PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'NEO4J')]
+    PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'elastic')
+    PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'elastic')

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -1,13 +1,11 @@
 import os
 
 # PROXY configuration keys
-PROXY_HOST = 'localhost'
-PROXY_PORT = '21000'
+PROXY_HOST = 'PROXY_HOST'
+PROXY_PORT = 'PROXY_PORT'
 PROXY_USER = 'PROXY_USER'
 PROXY_PASSWORD = 'PROXY_PASSWORD'
-PROXY_CLIENT = 'ATLAS'
-CREDENTIALS_PROXY_USER = 'admin'
-CREDENTIALS_PROXY_PASSWORD = 'admin'
+PROXY_CLIENT = 'PROXY_CLIENT'
 
 
 PROXY_CLIENTS = {
@@ -50,5 +48,3 @@ class LocalConfig(Config):
     PROXY_HOST = os.environ.get('PROXY_HOST', f'bolt://{LOCAL_HOST}')
     PROXY_PORT = os.environ.get('PROXY_PORT', 7687)
     PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'NEO4J')]
-    PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'elastic')
-    PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'elastic')

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -80,84 +80,75 @@ class AtlasProxy(BaseProxy):
 
         return entities_dict
 
-    def _extract_info_from_uri(self, *, table_uri: str) -> Dict:
-        """
-        Extracts the table information from table_uri coming from frontend.
-        :param table_uri:
-        :return: Dictionary object, containing following information:
-        entity: Database Namespace: rdbms_table, hive_table etc.
-        entity: Type of entity example: rdbms_table, hive_table etc.
-        cluster: Cluster information
-        db: Database Name
-        name: Unique Table Identifier
-        """
-        pattern = re.compile(r"""
-            ^   (?P<entity>.*?)
-            :\/\/
-                (?P<cluster>.*)
-            \.
-                (?P<db>.*?)
-            \/
-                (?P<name>.*?)
-            $
-        """, re.X)
-        result = pattern.match(table_uri)
-        return result.groupdict() if result else dict()
+    # def _extract_info_from_uri(self, *, table_uri: str) -> Dict:
+    #     """
+    #     Extracts the table information from table_uri coming from frontend.
+    #     :param table_uri:
+    #     :return: Dictionary object, containing following information:
+    #     entity: Database Namespace: rdbms_table, hive_table etc.
+    #     entity: Type of entity example: rdbms_table, hive_table etc.
+    #     cluster: Cluster information
+    #     db: Database Name
+    #     name: Unique Table Identifier
+    #     """
+    #     pattern = re.compile(r"""
+    #         ^   (?P<entity>.*?)
+    #         :\/\/
+    #             (?P<cluster>.*)
+    #         \.
+    #             (?P<db>.*?)
+    #         \/
+    #             (?P<name>.*?)
+    #         $
+    #     """, re.X)
+    #     result = pattern.match(table_uri)
+    #     return result.groupdict() if result else dict()
 
-    def _get_table_entity(self, *, table_uri: str) -> Tuple[EntityUniqueAttribute, Dict]:
+    def _get_table_entity(self, *, table_guid: str) -> Entity:
         """
         Fetch information from table_uri and then find the appropriate entity
         The reason, we're not returning the entity_unique_attribute().entity
         directly is because the entity_unique_attribute() return entity Object
         that can be used for update purposes,
         while entity_unique_attribute().entity only returns the dictionary
-        :param table_uri:
+        :param table_guid:
         :return:
         """
-        table_info = self._extract_info_from_uri(table_uri=table_uri)
-
         try:
-            return self._driver.entity_unique_attribute(
-                table_info['entity'],
-                qualifiedName=table_info.get('name')), table_info
+            return self._driver.entity_guid(table_guid)
         except Exception as ex:
             LOGGER.exception(f'Table not found. {str(ex)}')
-            raise NotFoundException('Table URI( {table_uri} ) does not exist'
-                                    .format(table_uri=table_uri))
+            raise NotFoundException('Table GUID( {table_guid} ) does not exist'
+                                    .format(table_guid=table_guid))
 
-    def _get_column(self, *, table_uri: str, column_name: str) -> Dict:
+    def _get_column(self, *, column_guid: str) -> Entity:
         """
         Fetch the column information from referredEntities of the table entity
-        :param table_uri:
-        :param column_name:
+        :param column_guid:
         :return: A dictionary containing the column details
         """
+
         try:
-            table_entity, _ = self._get_table_entity(table_uri=table_uri)
-            columns = table_entity.entity[self.REL_ATTRS_KEY].get('columns')
-            for column in columns or list():
-                col_details = table_entity.referredEntities[column['guid']]
-                if column_name == col_details[self.ATTRS_KEY][self.NAME_ATTRIBUTE]:
-                    return col_details
+            return self._driver.entity_guid(column_guid)
 
-            raise NotFoundException(f'Column not found: {column_name}')
-
-        except KeyError as ex:
+        except Exception as ex:
             LOGGER.exception(f'Column not found: {str(ex)}')
-            raise NotFoundException(f'Column not found: {column_name}')
+            raise NotFoundException(f'Column not found: {column_guid}')
 
     def get_user_detail(self, *, user_id: str) -> Union[UserEntity, None]:
         pass
 
-    def get_table(self, *, table_uri: str) -> Table:
+    def get_table(self, *, table_guid: str, table_info: Dict) -> Table:
         """
         Gathers all the information needed for the Table Detail Page.
-        :param table_uri:
+        :param table_guid:
+        :param table_info: Additional table information (entity, db, cluster, name)
         :return: A Table object with all the information available
         or gathered from different entities.
         """
-        entity, table_info = self._get_table_entity(table_uri=table_uri)
-        table_details = entity.entity
+
+        table_entity = self._get_table_entity(table_guid=table_guid)
+        table_details = table_entity.entity
 
         try:
             attrs = table_details[self.ATTRS_KEY]
@@ -175,7 +166,7 @@ class AtlasProxy(BaseProxy):
 
             columns = []
             for column in rel_attrs.get('columns') or list():
-                col_entity = entity.referredEntities[column['guid']]
+                col_entity = table_entity.referredEntities[column['guid']]
                 col_attrs = col_entity[self.ATTRS_KEY]
                 columns.append(
                     Column(
@@ -201,70 +192,70 @@ class AtlasProxy(BaseProxy):
             LOGGER.exception('Error while accessing table information. {}'
                              .format(str(ex)))
             raise BadRequest('Some of the required attributes '
-                             'are missing in : ( {table_uri} )'
-                             .format(table_uri=table_uri))
+                             'are missing in : ( {table_guid} )'
+                             .format(table_guid=table_guid))
 
-    def delete_owner(self, *, table_uri: str, owner: str) -> None:
+    def delete_owner(self, *, table_guid: str, owner: str) -> None:
         pass
 
-    def add_owner(self, *, table_uri: str, owner: str) -> None:
+    def add_owner(self, *, table_guid: str, owner: str) -> None:
         """
         It simply replaces the owner field in atlas with the new string.
         FixMe (Verdan): Implement multiple data owners and
         atlas changes in the documentation if needed to make owner field a list
-        :param table_uri:
+        :param table_guid:
         :param owner: Email address of the owner
         :return: None, as it simply adds the owner.
         """
-        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity = self._get_table_entity(table_guid=table_guid)
         entity.entity[self.ATTRS_KEY]['owner'] = owner
         entity.update()
 
     def get_table_description(self, *,
-                              table_uri: str) -> Union[str, None]:
+                              table_guid: str) -> Union[str, None]:
         """
-        :param table_uri:
+        :param table_guid:
         :return: The description of the table as a string
         """
-        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity = self._get_table_entity(table_guid=table_guid)
         return entity.entity[self.ATTRS_KEY].get('description')
 
     def put_table_description(self, *,
-                              table_uri: str,
+                              table_guid: str,
                               description: str) -> None:
         """
         Update the description of the given table.
-        :param table_uri:
+        :param table_guid:
         :param description: Description string
         :return: None
         """
-        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity = self._get_table_entity(table_guid=table_guid)
         entity.entity[self.ATTRS_KEY]['description'] = description
         entity.update()
 
-    def add_tag(self, *, table_uri: str, tag: str) -> None:
+    def add_tag(self, *, table_guid: str, tag: str) -> None:
         """
         Assign the tag/classification to the give table
         API Ref: /resource_EntityREST.html#resource_EntityREST_addClassification_POST
-        :param table_uri:
+        :param table_guid:
         :param tag: Tag/Classification Name
         :return: None
         """
-        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity = self._get_table_entity(table_guid=table_guid)
         entity_bulk_tag = {"classification": {"typeName": tag},
                            "entityGuids": [entity.entity['guid']]}
         self._driver.entity_bulk_classification.create(data=entity_bulk_tag)
 
-    def delete_tag(self, *, table_uri: str, tag: str) -> None:
+    def delete_tag(self, *, table_guid: str, tag: str) -> None:
         """
         Delete the assigned classfication/tag from the given table
         API Ref: /resource_EntityREST.html#resource_EntityREST_deleteClassification_DELETE
-        :param table_uri:
+        :param table_guid:
         :param tag:
         :return:
         """
         try:
-            entity, _ = self._get_table_entity(table_uri=table_uri)
+            entity = self._get_table_entity(table_guid=table_guid)
             guid_entity = self._driver.entity_guid(entity.entity['guid'])
             guid_entity.classifications(tag).delete()
         except Exception as ex:
@@ -273,37 +264,29 @@ class AtlasProxy(BaseProxy):
                              'but also always return exception. {}'.format(str(ex)))
 
     def put_column_description(self, *,
-                               table_uri: str,
-                               column_name: str,
+                               column_guid: str,
                                description: str) -> None:
         """
-        :param table_uri:
-        :param column_name: Name of the column to update the description
+        :param column_guid:
         :param description: The description string
         :return: None, as it simply updates the description of a column
         """
-        column_detail = self._get_column(
-            table_uri=table_uri,
-            column_name=column_name)
-        col_guid = column_detail['guid']
+        column_entity = self._get_column(
+            column_guid=column_guid)
 
-        entity = self._driver.entity_guid(col_guid)
-        entity.entity[self.ATTRS_KEY]['description'] = description
-        entity.update(attribute='description')
+        column_entity.entity[self.ATTRS_KEY]['description'] = description
+        column_entity.update(attribute='description')
 
     def get_column_description(self, *,
-                               table_uri: str,
-                               column_name: str) -> Union[str, None]:
+                               column_guid: str) -> Union[str, None]:
         """
-        :param table_uri:
+        :param column_guid:
         :param column_name:
-        :return: The column description using the referredEntities
-        information of a table entity
+        :return: The column description using the column guid
         """
-        column_detail = self._get_column(
-            table_uri=table_uri,
-            column_name=column_name)
-        return column_detail[self.ATTRS_KEY].get('description')
+        column_entity = self._get_column(
+            column_guid=column_guid)
+        return column_entity.entity[self.ATTRS_KEY].get('description')
 
     def get_popular_tables(self, *,
                            num_entries: int = 10) -> List[PopularTable]:
@@ -383,13 +366,13 @@ class AtlasProxy(BaseProxy):
         pass
 
     def add_table_relation_by_user(self, *,
-                                   table_uri: str,
+                                   table_guid: str,
                                    user_email: str,
                                    relation_type: UserResourceRel) -> None:
         pass
 
     def delete_table_relation_by_user(self, *,
-                                      table_uri: str,
+                                      table_guid: str,
                                       user_email: str,
                                       relation_type: UserResourceRel) -> None:
         pass

--- a/metadata_service/proxy/base_proxy.py
+++ b/metadata_service/proxy/base_proxy.py
@@ -18,45 +18,45 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_table(self, *, table_guid: str, table_info: Dict) -> Table:
+    def get_table(self, *, table_id: str, table_info: Dict) -> Table:
         pass
 
     @abstractmethod
-    def delete_owner(self, *, table_guid: str, owner: str) -> None:
+    def delete_owner(self, *, table_id: str, owner: str) -> None:
         pass
 
     @abstractmethod
-    def add_owner(self, *, table_guid: str, owner: str) -> None:
+    def add_owner(self, *, table_id: str, owner: str) -> None:
         pass
 
     @abstractmethod
     def get_table_description(self, *,
-                              table_guid: str) -> Union[str, None]:
+                              table_id: str) -> Union[str, None]:
         pass
 
     @abstractmethod
     def put_table_description(self, *,
-                              table_guid: str,
+                              table_id: str,
                               description: str) -> None:
         pass
 
     @abstractmethod
-    def add_tag(self, *, table_guid: str, tag: str) -> None:
+    def add_tag(self, *, table_id: str, tag: str) -> None:
         pass
 
     @abstractmethod
-    def delete_tag(self, *, table_guid: str, tag: str) -> None:
+    def delete_tag(self, *, table_id: str, tag: str) -> None:
         pass
 
     @abstractmethod
     def put_column_description(self, *,
-                               column_guid: str,
+                               column_id: str,
                                description: str) -> None:
         pass
 
     @abstractmethod
     def get_column_description(self, *,
-                               column_guid: str) -> Union[str, None]:
+                               column_id: str) -> Union[str, None]:
         pass
 
     @abstractmethod
@@ -79,14 +79,14 @@ class BaseProxy(metaclass=ABCMeta):
 
     @abstractmethod
     def add_table_relation_by_user(self, *,
-                                   table_guid: str,
+                                   table_id: str,
                                    user_email: str,
                                    relation_type: UserResourceRel) -> None:
         pass
 
     @abstractmethod
     def delete_table_relation_by_user(self, *,
-                                      table_guid: str,
+                                      table_id: str,
                                       user_email: str,
                                       relation_type: UserResourceRel) -> None:
         pass

--- a/metadata_service/proxy/base_proxy.py
+++ b/metadata_service/proxy/base_proxy.py
@@ -18,47 +18,45 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_table(self, *, table_uri: str) -> Table:
+    def get_table(self, *, table_guid: str, table_info: Dict) -> Table:
         pass
 
     @abstractmethod
-    def delete_owner(self, *, table_uri: str, owner: str) -> None:
+    def delete_owner(self, *, table_guid: str, owner: str) -> None:
         pass
 
     @abstractmethod
-    def add_owner(self, *, table_uri: str, owner: str) -> None:
+    def add_owner(self, *, table_guid: str, owner: str) -> None:
         pass
 
     @abstractmethod
     def get_table_description(self, *,
-                              table_uri: str) -> Union[str, None]:
+                              table_guid: str) -> Union[str, None]:
         pass
 
     @abstractmethod
     def put_table_description(self, *,
-                              table_uri: str,
+                              table_guid: str,
                               description: str) -> None:
         pass
 
     @abstractmethod
-    def add_tag(self, *, table_uri: str, tag: str) -> None:
+    def add_tag(self, *, table_guid: str, tag: str) -> None:
         pass
 
     @abstractmethod
-    def delete_tag(self, *, table_uri: str, tag: str) -> None:
+    def delete_tag(self, *, table_guid: str, tag: str) -> None:
         pass
 
     @abstractmethod
     def put_column_description(self, *,
-                               table_uri: str,
-                               column_name: str,
+                               column_guid: str,
                                description: str) -> None:
         pass
 
     @abstractmethod
     def get_column_description(self, *,
-                               table_uri: str,
-                               column_name: str) -> Union[str, None]:
+                               column_guid: str) -> Union[str, None]:
         pass
 
     @abstractmethod
@@ -81,14 +79,14 @@ class BaseProxy(metaclass=ABCMeta):
 
     @abstractmethod
     def add_table_relation_by_user(self, *,
-                                   table_uri: str,
+                                   table_guid: str,
                                    user_email: str,
                                    relation_type: UserResourceRel) -> None:
         pass
 
     @abstractmethod
     def delete_table_relation_by_user(self, *,
-                                      table_uri: str,
+                                      table_guid: str,
                                       user_email: str,
                                       relation_type: UserResourceRel) -> None:
         pass

--- a/tests/unit/api/test_redshit_disable_comment_edit.py
+++ b/tests/unit/api/test_redshit_disable_comment_edit.py
@@ -11,16 +11,16 @@ class RedshiftCommentEditDisableTest(unittest.TestCase):
         with patch('metadata_service.api.table.get_proxy_client'):
             tbl_dscrpt_api = TableDescriptionAPI()
 
-            table_guid = '8cfc0513-9a6b-4cdb-a4cc-f6549ed087cf'
-            response = tbl_dscrpt_api.put(table_guid=table_guid, description_val='test')
+            table_id = '8cfc0513-9a6b-4cdb-a4cc-f6549ed087cf'
+            response = tbl_dscrpt_api.put(table_id=table_id, description_val='test')
             self.assertEqual(list(response)[1], HTTPStatus.OK)
 
     def test_column_comment_edit(self) -> None:
         with patch('metadata_service.api.column.get_proxy_client'):
             col_dscrpt_api = ColumnDescriptionAPI()
 
-            column_guid = '5717362e-19a2-4bac-be49-0e4c5851300e'
-            response = col_dscrpt_api.put(column_guid=column_guid, description_val='test')
+            column_id = '5717362e-19a2-4bac-be49-0e4c5851300e'
+            response = col_dscrpt_api.put(column_id=column_id, description_val='test')
             self.assertEqual(list(response)[1], HTTPStatus.OK)
 
 

--- a/tests/unit/api/test_redshit_disable_comment_edit.py
+++ b/tests/unit/api/test_redshit_disable_comment_edit.py
@@ -11,16 +11,16 @@ class RedshiftCommentEditDisableTest(unittest.TestCase):
         with patch('metadata_service.api.table.get_proxy_client'):
             tbl_dscrpt_api = TableDescriptionAPI()
 
-            table_uri = 'hive://gold.test_schema/test_table'
-            response = tbl_dscrpt_api.put(table_uri=table_uri, description_val='test')
+            table_guid = '8cfc0513-9a6b-4cdb-a4cc-f6549ed087cf'
+            response = tbl_dscrpt_api.put(table_guid=table_guid, description_val='test')
             self.assertEqual(list(response)[1], HTTPStatus.OK)
 
     def test_column_comment_edit(self) -> None:
         with patch('metadata_service.api.column.get_proxy_client'):
             col_dscrpt_api = ColumnDescriptionAPI()
 
-            table_uri = 'hive://gold.test_schema/test_table'
-            response = col_dscrpt_api.put(table_uri=table_uri, column_name='foo', description_val='test')
+            column_guid = '5717362e-19a2-4bac-be49-0e4c5851300e'
+            response = col_dscrpt_api.put(column_guid=column_guid, description_val='test')
             self.assertEqual(list(response)[1], HTTPStatus.OK)
 
 

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -26,7 +26,7 @@ class TestAtlasProxy(unittest.TestCase):
         self.cluster = 'TEST_CLUSTER'
         self.db = 'TEST_DB'
         self.name = 'TEST_TABLE'
-        self.table_guid = '69cdc0de-1efa-428f-9c6e-5aa650c24138'
+        self.table_id = '69cdc0de-1efa-428f-9c6e-5aa650c24138'
 
         self.classification_entity = {
             'classifications': [
@@ -34,7 +34,7 @@ class TestAtlasProxy(unittest.TestCase):
             ]
         }
 
-        self.column_guid = "5717362e-19a2-4bac-be49-0e4c5851300e"
+        self.column_id = "5717362e-19a2-4bac-be49-0e4c5851300e"
         self.test_column = {
             'guid': '5717362e-19a2-4bac-be49-0e4c5851300e',
             'typeName': 'COLUMN',
@@ -161,7 +161,7 @@ class TestAtlasProxy(unittest.TestCase):
 
         self.proxy._driver.entity_guid = MagicMock(
             return_value=entity_guid_response)
-        ent = self.proxy._get_table_entity(table_guid=self.table_guid)
+        ent = self.proxy._get_table_entity(table_id=self.table_id)
         self.assertEqual(ent.__repr__(), entity_guid_response.__repr__())
 
     def test_get_table(self):
@@ -170,7 +170,7 @@ class TestAtlasProxy(unittest.TestCase):
                       'cluster': self.cluster,
                       'db': self.db,
                       'name': self.name}
-        response = self.proxy.get_table(table_guid=self.table_guid, table_info=table_info)
+        response = self.proxy.get_table(table_id=self.table_id, table_info=table_info)
 
         classif_name = self.classification_entity['classifications'][0]['typeName']
         ent_attrs = self.entity1['attributes']
@@ -198,7 +198,7 @@ class TestAtlasProxy(unittest.TestCase):
                       'name': self.name}
         with self.assertRaises(NotFoundException):
             self.proxy._driver.entity_guid = MagicMock(side_effect=Exception('Boom!'))
-            self.proxy.get_table(table_guid=self.table_guid, table_info=table_info)
+            self.proxy.get_table(table_id=self.table_id, table_info=table_info)
 
     def test_get_table_missing_info(self):
         with self.assertRaises(BadRequest):
@@ -208,7 +208,7 @@ class TestAtlasProxy(unittest.TestCase):
             entity_guid_response.entity = local_entity
 
             self.proxy._driver.entity_guid = MagicMock(return_value=entity_guid_response)
-            self.proxy.get_table(table_guid=self.table_guid, table_info={})
+            self.proxy.get_table(table_id=self.table_id, table_info={})
 
     def test_get_popular_tables(self):
         entity1 = MagicMock()
@@ -287,12 +287,12 @@ class TestAtlasProxy(unittest.TestCase):
 
     def test_get_table_description(self):
         self._mock_get_table_entity()
-        response = self.proxy.get_table_description(table_guid=self.table_guid)
+        response = self.proxy.get_table_description(table_id=self.table_id)
         self.assertEqual(response, self.entity1['attributes']['description'])
 
     def test_put_table_description(self):
         self._mock_get_table_entity()
-        self.proxy.put_table_description(table_guid=self.table_guid,
+        self.proxy.put_table_description(table_id=self.table_id,
                                          description="DOESNT_MATTER")
 
     def test_get_tags(self):
@@ -315,7 +315,7 @@ class TestAtlasProxy(unittest.TestCase):
         self._mock_get_table_entity()
 
         with patch.object(self.proxy._driver.entity_bulk_classification, 'create') as mock_execute:
-            self.proxy.add_tag(table_guid=self.table_guid, tag=tag)
+            self.proxy.add_tag(table_id=self.table_id, tag=tag)
             mock_execute.assert_called_with(
                 data={'classification': {'typeName': tag}, 'entityGuids': [self.entity1['guid']]}
             )
@@ -327,14 +327,14 @@ class TestAtlasProxy(unittest.TestCase):
         self.proxy._driver.entity_guid = MagicMock(return_value=mocked_entity)
 
         with patch.object(mocked_entity.classifications(tag), 'delete') as mock_execute:
-            self.proxy.delete_tag(table_guid=self.table_guid, tag=tag)
+            self.proxy.delete_tag(table_id=self.table_id, tag=tag)
             mock_execute.assert_called_with()
 
     def test_add_owner(self):
         owner = "OWNER"
         entity = self._mock_get_table_entity()
         with patch.object(entity, 'update') as mock_execute:
-            self.proxy.add_owner(table_guid=self.table_guid, owner=owner)
+            self.proxy.add_owner(table_id=self.table_id, owner=owner)
             mock_execute.assert_called_with()
 
     def test_get_column(self):
@@ -344,17 +344,17 @@ class TestAtlasProxy(unittest.TestCase):
     def test_get_column_wrong_guid(self):
         with self.assertRaises(NotFoundException):
             self.proxy._driver.entity_guid = MagicMock(side_effect=Exception('Boom!'))
-            self.proxy._get_column(column_guid=self.column_guid)
+            self.proxy._get_column(column_id=self.column_id)
 
     def test_get_column_description(self):
         self._mock_get_column()
         response = self.proxy.get_column_description(
-            column_guid=self.column_guid)
+            column_id=self.column_id)
         self.assertEqual(response, self.test_column['attributes'].get('description'))
 
     def test_put_column_description(self):
         self._mock_get_column()
-        self.proxy.put_column_description(column_guid=self.column_guid,
+        self.proxy.put_column_description(column_id=self.column_id,
                                           description='DOESNT_MATTER')
 
 


### PR DESCRIPTION
### Summary of Changes

Use entity guid instead of table uri. Finished Atlas part. To do FrontEnd and Neo4j.

### Tests

Modified test_atlas_proxy to test using of entity guid.
